### PR TITLE
Add db_server_info method

### DIFF
--- a/src/dbless-wpdb.php
+++ b/src/dbless-wpdb.php
@@ -141,6 +141,10 @@ class Db_Less_Wpdb extends wpdb {
 	public function db_version() {
 		return '10';
 	}
+
+	public function db_server_info() {
+		return false;
+	}
 }
 
 global $wpdb;


### PR DESCRIPTION
This PR adds a mock method to override `$wpdb->db_server_info()` in `dbless-wpdb.php`.

The purpose of this is to allow graceful execution of `dbDelta()` in WorDBless test cases. 

Currently, the `dbDelta` function calls `$wpdb->db_server_info()`, which will end up calling `mysql_get_server_info()`, which fatals. The reasons `mysql_get_server_info` breaks will either be due to the fact that it was removed in PHP 7.0.0, or if you're running an earlier version of PHP, because the method expects `$wpdb->dbh` to not be `false` or `null`.

Would this be a useful addition? While this doesn't necessarily add support for using `dbDelta` in WorDBless, it does prevent it from breaking when the function is executed inside a WorDBless test case.