### PR TITLE
Metadata: Add support for default metadata.

### DIFF
--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -81,8 +81,11 @@ class Metadata {
 				}
 			}
 		}
-		if ( empty( $check ) && $single ) {
-			$check = array( '' ); // Ensure an empty string is returned when meta is not found.
+		if ( empty( $check ) ) {
+			$check = get_metadata_default( $this->meta_type, $object_id, $meta_key, $single ); 
+			if ( $single ) {
+				$check = array( $check );
+			}
 		}
 		return $check;
 	}


### PR DESCRIPTION
The current implementation of `get` for the metadata returns the standard default of an empty string, or empty array, based on the `$single` parameter.

This change calls `get_default_metadata` so that any defaults added, along with the hooks, are respected.