### PR TITLE
Allow custom upload directories

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -237,4 +237,6 @@ jobs:
         run: "composer update --no-interaction --no-progress --no-suggest"
 
       - name: "Run integration tests with phpunit/phpunit"
-        run: "cp -f src/dbless-wpdb.php wordpress/wp-content/db.php && vendor/bin/phpunit --colors=always"
+        run: |
+          cp -f src/dbless-wpdb.php wordpress/wp-content/db.php
+          composer run-script phpunit

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
 		],
 		"phpunit": [
 			"@composer install",
-			"./vendor/phpunit/phpunit/phpunit --colors=always"
+			"./vendor/phpunit/phpunit/phpunit --colors=always --bootstrap tests/bootstrap.php --testsuite general",
+			"./vendor/phpunit/phpunit/phpunit --colors=always --bootstrap tests/bootstrap-uploads.php --testsuite uploads"
 		]
 	}
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,12 @@
-<phpunit bootstrap="tests/bootstrap.php" backupGlobals="false" colors="true">
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false" colors="true">
     <testsuites>
         <testsuite name="general">
             <directory prefix="test" suffix=".php">tests</directory>
+            <exclude>tests/test-uploads.php</exclude>
+        </testsuite>
+        <testsuite name="uploads">
+            <file>tests/test-uploads.php</file>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Load.php
+++ b/src/Load.php
@@ -19,7 +19,11 @@ class Load {
 
 		define( 'WP_REPAIRING', true ); // Will not try to install WordPress
 		define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content' );
-
+		if ( ! defined( 'UPLOADS' ) ) {
+			( defined( 'dbless_UPLOADS' ) )
+			? define( 'UPLOADS', WP_CONTENT_DIR . '/' . constant( '\dbless_UPLOADS' ) )
+			: define( 'UPLOADS', WP_CONTENT_DIR . '/uploads' );
+		}
 		$_SERVER['SERVER_NAME'] = 'anything.example';
 		$_SERVER['HTTP_HOST']   = 'anything.example';
 
@@ -28,8 +32,9 @@ class Load {
 
 		require ABSPATH . '/wp-settings.php';
 		require_once ABSPATH . 'wp-admin/includes/admin.php';
-		if ( ! file_exists( ABSPATH . 'wp-content/uploads' ) ) {
-			mkdir( ABSPATH . 'wp-content/uploads' );
+		// UPLOADS is defined by the time we get here, via a bootstrap.php or the code block above.
+		if ( ! file_exists( UPLOADS ) ) { // @phpstan-ignore constant.notFound
+			mkdir( UPLOADS ); // @phpstan-ignore constant.notFound
 		}
 
 		Options::init();

--- a/tests/bootstrap-uploads.php
+++ b/tests/bootstrap-uploads.php
@@ -1,0 +1,3 @@
+<?php
+define('dbless_UPLOADS', 'custom-uploads');
+require_once __DIR__ . '/bootstrap.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,7 +10,7 @@
  */
 require_once __DIR__ . '/../vendor/autoload.php';
 
-define( 'ABSPATH', __DIR__ . '/../wordpress/' );
+define( 'ABSPATH', realpath(__DIR__ . '/../wordpress/') . '/' );
 define( 'TESTSPATH', __DIR__ );
 define( 'WP_DEBUG', true );
 

--- a/tests/test-attachments.php
+++ b/tests/test-attachments.php
@@ -35,26 +35,34 @@ class Test_Attachments extends BaseTestCase {
 	}
 
 	public function test_add_attachment() {
-		$id = $this->create_upload_object( TESTSPATH . '/wp-logo.jpg' );
-		$this->assertTrue( is_int( $id ) );
-		$attachment = get_post( $id );
-		$this->assertEquals( 'attachment', $attachment->post_type );
+		$filename = TESTSPATH . '/wp-logo.jpg';
+		$contents = file_get_contents($filename);
+
+		// Add the attachment
+		$upload = wp_upload_bits(basename($filename), null, $contents);
+
+		$this->assertArrayHasKey('file', $upload, 'Upload result should contain "file" key');
+		$this->assertTrue(file_exists($upload['file']), 'Uploaded file should exist');
+
+		$id = $this->create_upload_object($filename);
+		$this->assertTrue(is_int($id));
+		$attachment = get_post($id);
+		$this->assertEquals('attachment', $attachment->post_type);
 	}
 
 	public function test_add_attachment_with_parent() {
-		$id = wp_insert_post( array( 'post_title' => 'Post 1' ) );
+		$id = wp_insert_post(array('post_title' => 'Post 1'));
 
-		$attachment_id = $this->create_upload_object( TESTSPATH . '/wp-logo.jpg', $id );
+		// Debug the upload in create_upload_object
+		$attachment_id = $this->create_upload_object(TESTSPATH . '/wp-logo.jpg', $id);
 
-		$attachment = get_post( $attachment_id );
+		$attachment = get_post($attachment_id);
 
-		$this->assertEquals( 'attachment', $attachment->post_type );
-		$this->assertEquals( $id, $attachment->post_parent );
+		$this->assertEquals('attachment', $attachment->post_type);
+		$this->assertEquals($id, $attachment->post_parent);
 
-		$this->assertTrue( wp_attachment_is_image( $attachment_id ) );
-
-		$this->assertStringStartsWith( '<img', wp_get_attachment_image( $attachment_id ) );
-
+		$this->assertTrue(wp_attachment_is_image($attachment_id));
+		$this->assertStringStartsWith('<img', wp_get_attachment_image($attachment_id));
 	}
 
 

--- a/tests/test-setup-teardown.php
+++ b/tests/test-setup-teardown.php
@@ -14,9 +14,16 @@ abstract class Test_Setup_Teardown_Base extends BaseTestCase {
 		$this->assertTrue( $this->setup_called, static::class . ' setup called?' );
 		$this->assertTrue( $this->custom_setup_called, static::class . ' custom setup called?' );
 		$this->assertNotEmpty( self::$hooks_saved, 'WorDBless setup called?' );
-
 		return true;
 	}
+
+	/**
+	 * This verifies that the default uploads directory is set correctly, as opposed to the custom one.
+	 * @covers Load::load
+	 */
+	public function test_default_uploads_directory() {
+        $this->assertEquals(WP_CONTENT_DIR . '/uploads', \UPLOADS);
+    }
 
 	/**
 	 * @depends test_setup_called

--- a/tests/test-uploads.php
+++ b/tests/test-uploads.php
@@ -1,0 +1,15 @@
+<?php
+namespace WorDBless;
+
+class Test_Uploads extends BaseTestCase {
+	/**
+	 * @covers Load::load
+	 * @covers dbless_UPLOADS
+	 *
+	 * This tests the custom uploads directory is set correctly.
+	 * The default directory is tested in test-setup-teardown.php.
+	 */
+    public function test_custom_uploads_directory() {
+        $this->assertEquals(WP_CONTENT_DIR . '/custom-uploads', UPLOADS);
+    }
+}


### PR DESCRIPTION
We've created a setup in the Jetpack monorepo ( https://github.com/Automattic/jetpack/pull/41057 ), that installs WorDBless once for a number of packages, then executes wordbless via a wrapper.

In individual, typical work, this works fine.

In our CI, we have the tests run concurrently, though, so we're hitting a situation where:
* package 1 starts the unit testing and kicks off wordbless.
* package 2 starts the unit testing and kicks off wordbless.
* p2 uploads an image as part of a test.
* p1 finishes, and calls wordbless' teardown which deletes the upload dir.
* p2 runs a test expecting the upload present.
* p2 fails.

For the moment, we're selectly installing wordbless via CI for those packages, but I'd like to update dbless to work as such:

* p1 starts unit testing with a constant of dbless_UPLOADS=uploads-p1
* p2 starts with dbless_UPLOADS=uploads-p2
* p2 uploads.
* p1 finishes, deletes uploads-p1
* p2 tests work, since the image is in uploads-p2
* p2 success, teardown will delete uploads-p2.

I believe this will do it, but will add a testing PR in Jetpack to consume this branch to confirm before merging.
