### PR TITLE
Correct usage of UPLOADS with tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	],
 	"require": {
 		"php": ">=7.2.24",
-		"roots/wordpress": "^6.6.2"
+		"roots/wordpress": "^6.6"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^7.5 || ^9.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "65270c4e43db1f093c5bb0124539ed81",
+    "content-hash": "11b1b7ef890ad1751f80625aeeb1a8b7",
     "packages": [
         {
             "name": "roots/wordpress",
-            "version": "6.7.1",
+            "version": "6.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/roots/wordpress.git",
-                "reference": "9451af491af7124c12186398c56ab87a6e145123"
+                "reference": "c53e4173d239dcaf8889f9f84c0b827a0cf643e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/roots/wordpress/zipball/9451af491af7124c12186398c56ab87a6e145123",
-                "reference": "9451af491af7124c12186398c56ab87a6e145123",
+                "url": "https://api.github.com/repos/roots/wordpress/zipball/c53e4173d239dcaf8889f9f84c0b827a0cf643e9",
+                "reference": "c53e4173d239dcaf8889f9f84c0b827a0cf643e9",
                 "shasum": ""
             },
             "require": {
@@ -39,7 +39,7 @@
             ],
             "support": {
                 "issues": "https://github.com/roots/wordpress/issues",
-                "source": "https://github.com/roots/wordpress/tree/6.7.1"
+                "source": "https://github.com/roots/wordpress/tree/6.7.2"
             },
             "funding": [
                 {
@@ -47,7 +47,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-11-13T09:56:09+00:00"
+            "time": "2024-12-15T16:32:37+00:00"
         },
         {
             "name": "roots/wordpress-core-installer",
@@ -122,22 +122,22 @@
         },
         {
             "name": "roots/wordpress-no-content",
-            "version": "6.7.1",
+            "version": "6.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress.git",
-                "reference": "6.7.1"
+                "reference": "6.7.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/release/wordpress-6.7.1-no-content.zip",
-                "shasum": "321a5b819369e772ce606fbc12b1e264fb73da5b"
+                "url": "https://downloads.wordpress.org/release/wordpress-6.7.2-no-content.zip",
+                "shasum": "c33ca276601dee0ddf1e80d3e66403929a696e63"
             },
             "require": {
                 "php": ">= 7.2.24"
             },
             "provide": {
-                "wordpress/core-implementation": "6.7.1"
+                "wordpress/core-implementation": "6.7.2"
             },
             "suggest": {
                 "ext-curl": "Performs remote request operations.",
@@ -188,7 +188,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2024-11-21T14:15:19+00:00"
+            "time": "2025-02-11T16:29:31+00:00"
         }
     ],
     "packages-dev": [
@@ -264,16 +264,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.1",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
+                "reference": "024473a478be9df5fdaca2c793f2232fe788e414"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/024473a478be9df5fdaca2c793f2232fe788e414",
+                "reference": "024473a478be9df5fdaca2c793f2232fe788e414",
                 "shasum": ""
             },
             "require": {
@@ -312,7 +312,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.0"
             },
             "funding": [
                 {
@@ -320,7 +320,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-08T17:47:46+00:00"
+            "time": "2025-02-12T12:17:51+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -1935,16 +1935,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "0b31ce834facf03b8b44b6587e65b3cf1d7cfb94"
+                "reference": "e6faedf5e34cea4438e341f660e2f719760c531d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/0b31ce834facf03b8b44b6587e65b3cf1d7cfb94",
-                "reference": "0b31ce834facf03b8b44b6587e65b3cf1d7cfb94",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/e6faedf5e34cea4438e341f660e2f719760c531d",
+                "reference": "e6faedf5e34cea4438e341f660e2f719760c531d",
                 "shasum": ""
             },
             "require": {
@@ -1959,7 +1959,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.x-dev"
+                    "dev-main": "4.x-dev"
                 }
             },
             "autoload": {
@@ -1994,7 +1994,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2025-01-08T16:58:34+00:00"
+            "time": "2025-02-09T18:13:44+00:00"
         }
     ],
     "aliases": [],

--- a/src/BaseTestCase.php
+++ b/src/BaseTestCase.php
@@ -39,7 +39,7 @@ abstract class BaseTestCase extends TestCase {
 	 * @return void
 	 */
 	public function clear_uploads() {
-		$uploads_folder = ABSPATH . UPLOADS;
+		$uploads_folder = wp_get_upload_dir()['basedir'];
 		$scan           = glob( rtrim( $uploads_folder, '/' ) . '/*' );
 
 		foreach ( $scan as $path ) {

--- a/src/BaseTestCase.php
+++ b/src/BaseTestCase.php
@@ -39,7 +39,7 @@ abstract class BaseTestCase extends TestCase {
 	 * @return void
 	 */
 	public function clear_uploads() {
-		$uploads_folder = ABSPATH . '/wp-content/uploads';
+		$uploads_folder = ABSPATH . UPLOADS;
 		$scan           = glob( rtrim( $uploads_folder, '/' ) . '/*' );
 
 		foreach ( $scan as $path ) {

--- a/src/Load.php
+++ b/src/Load.php
@@ -33,8 +33,8 @@ class Load {
 		require ABSPATH . '/wp-settings.php';
 		require_once ABSPATH . 'wp-admin/includes/admin.php';
 		// UPLOADS is defined by the time we get here, via a bootstrap.php or the code block above.
-		if ( ! file_exists( UPLOADS ) ) { // @phpstan-ignore constant.notFound
-			mkdir( UPLOADS ); // @phpstan-ignore constant.notFound
+		if ( ! file_exists( ABSPATH . UPLOADS ) ) { // @phpstan-ignore constant.notFound
+			mkdir( ABSPATH . UPLOADS ); // @phpstan-ignore constant.notFound
 		}
 
 		Options::init();

--- a/tests/test-setup-teardown.php
+++ b/tests/test-setup-teardown.php
@@ -22,8 +22,16 @@ abstract class Test_Setup_Teardown_Base extends BaseTestCase {
 	 * @covers Load::load
 	 */
 	public function test_default_uploads_directory() {
-        $this->assertEquals(WP_CONTENT_DIR . '/uploads', \UPLOADS);
+        $this->assertEquals(WP_CONTENT_DIR . '/uploads', ABSPATH . UPLOADS);
     }
+
+	/**
+	 * This verifies that WordPress sees the default uploads directory.
+	 * @covers Load::load
+	 */
+	public function test_default_uploads_directory_is_recognized() {
+		$this->assertEquals( wp_upload_dir()['path'], ABSPATH . UPLOADS);
+	}
 
 	/**
 	 * @depends test_setup_called

--- a/tests/test-uploads.php
+++ b/tests/test-uploads.php
@@ -10,6 +10,27 @@ class Test_Uploads extends BaseTestCase {
 	 * The default directory is tested in test-setup-teardown.php.
 	 */
     public function test_custom_uploads_directory() {
-        $this->assertEquals(WP_CONTENT_DIR . '/custom-uploads', UPLOADS);
+        $this->assertEquals(WP_CONTENT_DIR . '/custom-uploads', ABSPATH . UPLOADS);
     }
+
+	/**
+	 * @covers Load::load
+	 * @covers dbless_UPLOADS
+	 *
+	 * This tests the custom uploads directory is created correctly by Load::load.
+	 *
+	 * This test must run before any tests that use the uploads directory or call wp_upload_dir() which will create the uploads directory if it doesn't exist.
+	 */
+	public function test_custom_uploads_directory_is_created() {
+		$this->assertTrue(file_exists(ABSPATH . UPLOADS));
+	}
+
+	/**
+	 * @covers Load::load
+	 *
+	 * This test confirms that WordPress sees the custom uploads directory.
+	 */
+	public function test_custom_uploads_directory_is_recognized() {
+		$this->assertEquals( wp_upload_dir()['path'], ABSPATH . UPLOADS);
+	}
 }


### PR DESCRIPTION
In #70, I missed that WordPress automatically combines ABSPATH and UPLOADS when using wp_upload_dir, so the tests created worked, but when actually needing to use the custom dir, it didn't.

Added a test that checked for the existence of the folder (which should happen in Load:load()) which failed when it was created UPLOADS and passed when creating ABSPATH.UPLOADS.
