### PR TITLE
BaseTestCase: Add attributes for PHPUnit 11+

### DIFF
--- a/src/BaseTestCase.php
+++ b/src/BaseTestCase.php
@@ -2,6 +2,8 @@
 
 namespace WorDBless;
 
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 abstract class BaseTestCase extends TestCase {
@@ -13,6 +15,7 @@ abstract class BaseTestCase extends TestCase {
 	 *
 	 * @before
 	 */
+	#[Before]
 	public function set_up_wordbless() {
 		if ( ! self::$hooks_saved ) {
 			$this->_backup_hooks();
@@ -24,6 +27,7 @@ abstract class BaseTestCase extends TestCase {
 	 *
 	 * @after
 	 */
+	#[After]
 	public function tear_down_wordbless() {
 		$this->_restore_hooks();
 		Options::init()->clear_options();


### PR DESCRIPTION
PHPUnit 11 has deprecated annotations such as `@before` and `@after` in favor of attributes like `#[Before]` and `#[After]`. PHPUnit 12 removes support for the annotations entirely.

We can safely add the attributes even for earlier versions, as PHP 7 sees them as comments and PHP 8 doesn't require that the corresponding class actually exists.