### PR TITLE
Fix warning with WordPress 6.8

### DIFF
--- a/src/Composer/InstallDropin.php
+++ b/src/Composer/InstallDropin.php
@@ -12,6 +12,9 @@ class InstallDropin {
 		if ( ! is_dir( 'wordpress/wp-content' ) ) {
 			mkdir( 'wordpress/wp-content', 0777, true );
 		}
+		if ( ! is_dir( 'wordpress/wp-content/themes' ) ) {
+			mkdir( 'wordpress/wp-content/themes', 0777, true );
+		}
 
 		copy( dirname( __DIR__ ) . '/dbless-wpdb.php', 'wordpress/wp-content/db.php' );
 	}


### PR DESCRIPTION
If the `wp-content/themes` directory does not exist, `register_theme_directory()` will fail to register the default theme directory. Starting in WordPress 6.8, `wp_is_block_theme()` called during init will then issue a doing-it-wrong about being called before the theme directory is registered.

`roots/wordpress` does not create a `wp-content/themes` directory by default, and hasn't for a while. In order for things to work, we should create it if it doesn't exist.