### PR TITLE
Fix `get_metadata( $single = true )` when the default is an array

### DIFF
--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -79,7 +79,11 @@ class Metadata {
 			}
 		}
 		if ( empty( $check ) ) {
-			return get_metadata_default( $this->meta_type, $object_id, $meta_key, $single );
+			$default = get_metadata_default( $this->meta_type, $object_id, $meta_key, $single );
+			// We're trying to reproduce the `get_metadata()` behavior of returning the result of `get_metadata_default()` when no object metadata is set.
+			// But Core's `get_metadata_raw()` that calls us will try to unwrap our return value if $single and it's array, so we need to wrap it.
+			// Note this breaks `metadata_exists()` if `$default` is an empty array though.
+			return $single && is_array( $default ) ? array( $default ) : $default;
 		}
 		return $check;
 	}

--- a/tests/test-posts.php
+++ b/tests/test-posts.php
@@ -290,11 +290,28 @@ class Test_Posts extends BaseTestCase {
 		$this->assertSame( false, metadata_exists('post', 1234, 'asdasd') );
 	}
 
-	public function test_get_existent_meta() {		
+	public function test_get_existent_meta() {
 		$id = wp_insert_post( array( 'post_title' => 'Post 1' ) );
 		$this->assertSame( false, metadata_exists('post', $id, 'test') );
 		add_post_meta( $id, 'test', 'value-1' );
 		$this->assertSame( true, metadata_exists('post', $id, 'test') );
+	}
+
+	public function test_get_non_existent_meta_with_default() {
+		$id = wp_insert_post( array( 'post_title' => 'Post 1' ) );
+		add_filter(
+			'default_post_metadata',
+			function ( $value, $object_id ) use ( $id ) {
+				if ( $object_id === $id ) {
+					return array( 'foo' => 42 );
+				}
+				return $value;
+			},
+			10,
+			2
+		);
+		$this->assertSame( array( array( 'foo' => 42 ) ), get_post_meta( $id, 'asdasd', false ) );
+		$this->assertSame( array( 'foo' => 42 ), get_post_meta( $id, 'asdasd', true ) );
 	}
 
 }


### PR DESCRIPTION
PR #77 attempted to fix `get_metadata( $single = true )` to return the default metadata rather than always returning an empty string.

Unfortunately the code calling the filter will attempt to unwrap the return value if the return value is an array; it'll blow up if `$ret[0]` is not set, or return that instead of the whole default if it does. To fix it, we can wrap the value if it's an array.

This does re-break `metadata_exists()` for the specific case where the default metadata is an empty array: normally `metadata_exists()` would consider that as non-existing, but for WorDBless it will count it as existing instead. Other than inspecting the call stack, though, I don't see a way around this.