### PR TITLE
Refactor SQLite initialization: Move cleanup logic to the SQLite block

### DIFF
--- a/src/Load.php
+++ b/src/Load.php
@@ -17,10 +17,6 @@ class Load {
 	 * @return void
 	 */
 	public static function load( $db_engine = 'dbless', $persist = false ) {
-		if ( ! $persist ) {
-			// Clean up any existing SQLite database files.
-			Sqlite::cleanup();
-		}
 		if ( ! defined( 'ABSPATH' ) ) {
 			define( 'ABSPATH', __DIR__ . '/../../../../wordpress/' );
 		}
@@ -62,6 +58,11 @@ class Load {
 			UserMeta::init();
 			WpDie::init();
 		} elseif ( DB_ENGINE === 'sqlite' ) {
+			if ( ! $persist ) {
+				// Clean up any existing SQLite database files.
+				Sqlite::cleanup();
+			}
+
 			Sqlite::init();
 		}
 	}


### PR DESCRIPTION
When calling `\WorDBless\Load::load();`  I do get an error because the `ABSPATH` isn't defined.

This seems to be caused by the fact that the `\WorDBless\Load::load()`  internally calls `Sqlite::cleanup();`  before the `ABSPATH` is defined.
You can see it at https://github.com/Automattic/wordbless/blob/trunk/src/Load.php#L20-L26

I'm not familiar with the project but looks like it might make sense to execute the cleanup only if the DB Engine is set to `sqlite`  and after the main tasks.