### PR TITLE
Allow WordPress 7.0 in roots/wordpress constraint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           extensions: "${{ env.PHP_EXTENSIONS }}"
           coverage: "none"
-          tools: "composer:2.2"
+          tools: "composer:v2"
 
       - name: "Validate composer.json and composer.lock"
         run: "composer validate --strict"
@@ -73,24 +73,26 @@ jobs:
 
       - name: "Install lowest dependencies from composer.json"
         if: "matrix.dependencies == 'lowest'"
-        run: "composer update --no-interaction --no-progress --no-suggest --prefer-lowest"
+        run: "composer update --no-interaction --no-progress --prefer-lowest"
 
       - name: "Install locked dependencies from composer.lock"
         if: "matrix.dependencies == 'locked'"
-        run: "composer install --no-interaction --no-progress --no-suggest"
+        run: "composer install --no-interaction --no-progress"
 
       - name: "Install highest dependencies from composer.json"
         if: "matrix.dependencies == 'highest'"
-        run: "composer update --no-interaction --no-progress --no-suggest"
+        run: "composer update --no-interaction --no-progress"
 
       - name: "Run ergebnis/composer-normalize"
         run: "tools/composer-normalize normalize --dry-run"
 
       - name: "Run wp-coding-standards/wpcs"
         run: |
-          composer require --working-dir=tools "wp-coding-standards/wpcs:^2.3.0"
-          tools/phpcs --config-set installed_paths tools/vendor/wp-coding-standards/wpcs
-          tools/phpcs -s --standard=WordPress-Core --exclude=WordPress.Files.FileName --ignore=*/sqlite-database-integration/* src/
+          test -f tools/composer.json || echo '{}' > tools/composer.json
+          composer config --working-dir=tools allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+          composer require --working-dir=tools "wp-coding-standards/wpcs:^3.1.0" "phpcsstandards/phpcsutils:^1.0" "phpcsstandards/phpcsextra:^1.0"
+          tools/vendor/bin/phpcs --config-set installed_paths tools/vendor/wp-coding-standards/wpcs,tools/vendor/phpcsstandards/phpcsutils,tools/vendor/phpcsstandards/phpcsextra
+          tools/vendor/bin/phpcs -s --standard=WordPress-Core --exclude=WordPress.Files.FileName --ignore=*/sqlite-database-integration/* src/
 
   static-code-analysis:
     name: "Static Code Analysis"
@@ -115,7 +117,7 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           extensions: "${{ env.PHP_EXTENSIONS }}"
           coverage: "none"
-          tools: "composer:2.2"
+          tools: "composer:v2"
 
       - name: "Determine composer cache directory"
         shell: "bash"
@@ -148,15 +150,15 @@ jobs:
 
       - name: "Install lowest dependencies from composer.json"
         if: "matrix.dependencies == 'lowest'"
-        run: "composer update --no-interaction --no-progress --no-suggest --prefer-lowest"
+        run: "composer update --no-interaction --no-progress --prefer-lowest"
 
       - name: "Install locked dependencies from composer.lock"
         if: "matrix.dependencies == 'locked'"
-        run: "composer install --no-interaction --no-progress --no-suggest"
+        run: "composer install --no-interaction --no-progress"
 
       - name: "Install highest dependencies from composer.json"
         if: "matrix.dependencies == 'highest'"
-        run: "composer update --no-interaction --no-progress --no-suggest"
+        run: "composer update --no-interaction --no-progress"
 
       - name: "Create cache directory for phpstan/phpstan"
         run: "mkdir -p .build/phpstan"
@@ -181,6 +183,10 @@ jobs:
     strategy:
       matrix:
         php-version:
+          - "8.4"
+          - "8.3"
+          - "8.2"
+          - "8.1"
           - "8.0"
           - "7.4"
           - "7.3"
@@ -192,12 +198,14 @@ jobs:
           - "highest"
 
         exclude:
-          # Locked dependencies require PHP 7.3+.
+          # Locked/highest dependencies require PHP 7.3+.
           - php-version: "7.2"
             dependencies: "locked"
-          # Highest dependencies require PHP 7.3+
           - php-version: "7.2"
             dependencies: "highest"
+          # Lowest PHPUnit 9.5.x predates PHP 8.4 and is incompatible.
+          - php-version: "8.4"
+            dependencies: "lowest"
 
     steps:
       - name: "Checkout"
@@ -209,7 +217,7 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           extensions: "${{ env.PHP_EXTENSIONS }}"
           coverage: "none"
-          tools: "composer:2.2"
+          tools: "composer:v2"
 
       - name: "Determine composer cache directory"
         shell: "bash"
@@ -222,19 +230,73 @@ jobs:
           key: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('composer.lock') }}"
           restore-keys: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-"
 
+      - name: "Remove platform PHP override"
+        run: "composer config --unset platform.php"
+
+      - name: "Pin PHPUnit 7.5 for PHP 7.2 and ignore its security advisory"
+        if: "matrix.php-version == '7.2'"
+        run: |
+          composer config audit.ignore '["PKSA-z3gr-8qht-p93v"]' --json
+          composer require --no-update --no-interaction --dev 'phpunit/phpunit:^7.5'
+
       - name: "Install lowest dependencies from composer.json"
         if: "matrix.dependencies == 'lowest'"
-        run: |
-          composer require --no-update --no-interaction --no-progress --no-suggest --dev 'phpunit/phpunit:^7.5 || ^9.5'
-          composer update --no-interaction --no-progress --no-suggest --prefer-lowest --dev
+        run: "composer update --no-interaction --no-progress --prefer-lowest"
 
       - name: "Install locked dependencies from composer.lock"
         if: "matrix.dependencies == 'locked'"
-        run: "composer install --no-interaction --no-progress --no-suggest"
+        run: "composer install --no-interaction --no-progress"
 
       - name: "Install highest dependencies from composer.json"
         if: "matrix.dependencies == 'highest'"
-        run: "composer update --no-interaction --no-progress --no-suggest"
+        run: "composer update --no-interaction --no-progress"
+
+      - name: "Run integration tests with phpunit/phpunit"
+        run: |
+          cp -f src/dbless-wpdb.php wordpress/wp-content/db.php
+          composer run-script phpunit
+
+  wp-trunk-tests:
+    name: "Tests (WP trunk)"
+
+    runs-on: "ubuntu-24.04"
+    continue-on-error: true
+
+    strategy:
+      matrix:
+        php-version:
+          - "8.4"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: "Install PHP with extensions"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ matrix.php-version }}"
+          extensions: "${{ env.PHP_EXTENSIONS }}"
+          coverage: "none"
+          tools: "composer:v2"
+
+      - name: "Determine composer cache directory"
+        shell: "bash"
+        run: "echo \"COMPOSER_CACHE_DIR=$(composer config cache-dir)\" >> $GITHUB_ENV"
+
+      - name: "Cache dependencies installed with composer"
+        uses: "actions/cache@v4"
+        with:
+          path: "${{ env.COMPOSER_CACHE_DIR }}"
+          key: "php-${{ matrix.php-version }}-composer-wp-trunk-${{ github.sha }}"
+          restore-keys: "php-${{ matrix.php-version }}-composer-wp-trunk-"
+
+      - name: "Install dependencies with WP trunk"
+        run: |
+          composer config --unset platform.php
+          composer config minimum-stability dev
+          composer config prefer-stable true
+          composer require --no-update "roots/wordpress:dev-main"
+          composer update --no-interaction --no-progress
 
       - name: "Run integration tests with phpunit/phpunit"
         run: |

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	],
 	"require": {
 		"php": ">=7.2.24",
-		"roots/wordpress": "^6.6"
+		"roots/wordpress": "^6.6 || ^7.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^7.5 || ^9.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11b1b7ef890ad1751f80625aeeb1a8b7",
+    "content-hash": "bec1a38e7a3d8814eeddf8a18770d1b4",
     "packages": [
         {
             "name": "roots/wordpress",
-            "version": "6.7.2",
+            "version": "6.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/roots/wordpress.git",
-                "reference": "c53e4173d239dcaf8889f9f84c0b827a0cf643e9"
+                "reference": "29e4eb49b2f4c591e39d4eb6705a27cf1ea40e45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/roots/wordpress/zipball/c53e4173d239dcaf8889f9f84c0b827a0cf643e9",
-                "reference": "c53e4173d239dcaf8889f9f84c0b827a0cf643e9",
+                "url": "https://api.github.com/repos/roots/wordpress/zipball/29e4eb49b2f4c591e39d4eb6705a27cf1ea40e45",
+                "reference": "29e4eb49b2f4c591e39d4eb6705a27cf1ea40e45",
                 "shasum": ""
             },
             "require": {
-                "roots/wordpress-core-installer": "^1.0.0",
+                "roots/wordpress-core-installer": "^3.0",
                 "roots/wordpress-no-content": "self.version"
             },
             "type": "metapackage",
@@ -39,7 +39,7 @@
             ],
             "support": {
                 "issues": "https://github.com/roots/wordpress/issues",
-                "source": "https://github.com/roots/wordpress/tree/6.7.2"
+                "source": "https://github.com/roots/wordpress/tree/6.9.1"
             },
             "funding": [
                 {
@@ -47,25 +47,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-15T16:32:37+00:00"
+            "time": "2025-05-23T18:54:22+00:00"
         },
         {
             "name": "roots/wordpress-core-installer",
-            "version": "1.100.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/roots/wordpress-core-installer.git",
-                "reference": "73f8488e5178c5d54234b919f823a9095e2b1847"
+                "reference": "714d2e2a9e523f6e7bde4810d5a04aedf0ec217f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/roots/wordpress-core-installer/zipball/73f8488e5178c5d54234b919f823a9095e2b1847",
-                "reference": "73f8488e5178c5d54234b919f823a9095e2b1847",
+                "url": "https://api.github.com/repos/roots/wordpress-core-installer/zipball/714d2e2a9e523f6e7bde4810d5a04aedf0ec217f",
+                "reference": "714d2e2a9e523f6e7bde4810d5a04aedf0ec217f",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.6.0"
+                "php": ">=7.2.24"
             },
             "conflict": {
                 "composer/installers": "<1.0.6"
@@ -75,7 +75,7 @@
             },
             "require-dev": {
                 "composer/composer": "^1.0 || ^2.0",
-                "phpunit/phpunit": ">=5.7.27"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "composer-plugin",
             "extra": {
@@ -100,44 +100,41 @@
                     "email": "team@roots.io"
                 }
             ],
-            "description": "A custom installer to handle deploying WordPress with composer",
+            "description": "A Composer custom installer to handle installing WordPress as a dependency",
             "keywords": [
                 "wordpress"
             ],
             "support": {
                 "issues": "https://github.com/roots/wordpress-core-installer/issues",
-                "source": "https://github.com/roots/wordpress-core-installer/tree/master"
+                "source": "https://github.com/roots/wordpress-core-installer/tree/3.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/roots",
                     "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/rootsdev",
-                    "type": "patreon"
                 }
             ],
-            "time": "2020-08-20T00:27:30+00:00"
+            "time": "2025-05-23T18:47:25+00:00"
         },
         {
             "name": "roots/wordpress-no-content",
-            "version": "6.7.2",
+            "version": "6.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress.git",
-                "reference": "6.7.2"
+                "reference": "6.9.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/release/wordpress-6.7.2-no-content.zip",
-                "shasum": "c33ca276601dee0ddf1e80d3e66403929a696e63"
+                "url": "https://downloads.wordpress.org/release/wordpress-6.9.1-no-content.zip",
+                "reference": "6.9.1",
+                "shasum": "27121719e788b7c9e35cfcf8984ad8b42bd423d6"
             },
             "require": {
                 "php": ">= 7.2.24"
             },
             "provide": {
-                "wordpress/core-implementation": "6.7.2"
+                "wordpress/core-implementation": "6.9.1"
             },
             "suggest": {
                 "ext-curl": "Performs remote request operations.",
@@ -188,7 +185,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2025-02-11T16:29:31+00:00"
+            "time": "2026-02-03T17:39:17+00:00"
         }
     ],
     "packages-dev": [
@@ -819,16 +816,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.33",
+            "version": "9.6.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "fea06253ecc0a32faf787bd31b261f56f351d049"
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fea06253ecc0a32faf787bd31b261f56f351d049",
-                "reference": "fea06253ecc0a32faf787bd31b261f56f351d049",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
                 "shasum": ""
             },
             "require": {
@@ -902,7 +899,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.33"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
             },
             "funding": [
                 {
@@ -926,7 +923,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T05:25:09+00:00"
+            "time": "2026-01-27T05:45:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1991,16 +1988,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "e6faedf5e34cea4438e341f660e2f719760c531d"
+                "reference": "41aaac462fbd80feb8dd129e489f4bbc53fe26b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/e6faedf5e34cea4438e341f660e2f719760c531d",
-                "reference": "e6faedf5e34cea4438e341f660e2f719760c531d",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/41aaac462fbd80feb8dd129e489f4bbc53fe26b0",
+                "reference": "41aaac462fbd80feb8dd129e489f4bbc53fe26b0",
                 "shasum": ""
             },
             "require": {
@@ -2010,7 +2007,7 @@
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "yoast/yoastcs": "^3.1.0"
+                "yoast/yoastcs": "^3.2.0"
             },
             "type": "library",
             "extra": {
@@ -2050,7 +2047,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2025-02-09T18:13:44+00:00"
+            "time": "2025-08-10T04:54:36+00:00"
         }
     ],
     "aliases": [],
@@ -2065,5 +2062,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Summary

- Widen `roots/wordpress` constraint from `^6.6` to `^6.6 || ^7.0` so consumers can test against WP 7.0 trunk.
- Expand CI test matrix to cover PHP 8.1-8.4 alongside the existing 7.2-8.0.
- Add a separate WP trunk job (`continue-on-error: true`) that tests against `roots/wordpress:dev-main`.
- Fix the coding standards step to use the Composer-installed phpcs (`tools/vendor/bin/phpcs`) instead of the PHIVE PHAR, which is too old for WPCS 3.x sniffs.
- For the PHP 7.2 lowest-deps job, ignore the Composer 2.8 security advisory (`PKSA-z3gr-8qht-p93v`) that blocks PHPUnit < 9.6.33, and pin PHPUnit to `^7.5` (the only available version that supports PHP 7.2). The advisory only affects the test runner in an isolated CI environment, not shipped code.
- Exclude PHP 8.4 from the lowest-deps strategy since PHPUnit 9.5.0 (the lowest resolvable version) predates PHP 8.4 and is incompatible with it.

## Test plan

- [x] `composer update` succeeds and resolves dependencies
- [x] All three PHPUnit test suites pass (general, uploads, sqlite)
- [ ] CI passes on all matrix combinations