### PR TITLE
Load: Define ABSPATH before SQLite cleanup and scope cleanup to sqlite engine

### DIFF
--- a/src/Load.php
+++ b/src/Load.php
@@ -17,12 +17,12 @@ class Load {
 	 * @return void
 	 */
 	public static function load( $db_engine = 'dbless', $persist = false ) {
-		if ( ! $persist ) {
-			// Clean up any existing SQLite database files.
-			Sqlite::cleanup();
-		}
 		if ( ! defined( 'ABSPATH' ) ) {
 			define( 'ABSPATH', __DIR__ . '/../../../../wordpress/' );
+		}
+		if ( ! $persist && 'sqlite' === strtolower( $db_engine ) ) {
+			// Clean up any existing SQLite database files.
+			Sqlite::cleanup();
 		}
 
 		define( 'WP_REPAIRING', true ); // Will not try to install WordPress


### PR DESCRIPTION
## Summary

- Defines `ABSPATH` before calling `Sqlite::cleanup()`, which uses it (fixes the undefined constant warning)
- Scopes `Sqlite::cleanup()` to only run when the engine is `sqlite`, since it's a no-op for other engines
- Keeps cleanup before `wp-settings.php` loads so WordPress boots with a clean state

Combines the best of #80 and #81 — #81's approach of defining `ABSPATH` first, and #80's insight that cleanup should be scoped to the sqlite engine.

Fixes and closes #80 
Fixes and closes #81