### PR TITLE
Fix: minor grammatical issues in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Here is a non-exaustive list of functions supported:
 * `add_user_meta`
 * `delete_user_meta`
 
-Posts can be assigned to users and proper capabilities will be correctly checked. When deleting a user, reassigning posts to other user will also work.
+Posts can be assigned to users and proper capabilities will be correctly checked. When deleting a user, reassigning posts to other users will also work.
 
 Note: Fetching users using `WP_Users_Query` will not work! To fetch a user, use `get_userdata()`, `get_user_by` or `WP_User` class.
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ By default, only `siteurl` and `home` options are populated with `http://example
 
 If you want, you can add more options to be loaded by default. 
 
-Just declare a `dbless_default_options()` function in your bootstrap and make it return an array where the keys are option names and values, options values.
+Just declare a `dbless_default_options()` function in your bootstrap and make it return an array where the keys are option names and the values are option values.
 
 ## Examples
 


### PR DESCRIPTION
This PR addresses two small grammatical issues found in README.md file:

1. **User deletion documentation** – Changes "to other user" to "to other users" for proper plural agreement.

2. **dbless_default_options documentation** – Clarifies the expected return array structure from ambiguous wording to a clear parallel construction: "keys are option names and the values are option values."

These changes improve readability and reduce potential confusion for developers reading the documentation.

No functional code changes are included.