### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Install PHP with extensions"
-        uses: "shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc" # 2.37.1
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # 2.37.2
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: "${{ env.PHP_EXTENSIONS }}"
@@ -112,7 +112,7 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Install PHP with extensions"
-        uses: "shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc" # 2.37.1
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # 2.37.2
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: "${{ env.PHP_EXTENSIONS }}"
@@ -212,7 +212,7 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Install PHP with extensions"
-        uses: "shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc" # 2.37.1
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # 2.37.2
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: "${{ env.PHP_EXTENSIONS }}"
@@ -272,7 +272,7 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Install PHP with extensions"
-        uses: "shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc" # 2.37.1
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # 2.37.2
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: "${{ env.PHP_EXTENSIONS }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Install PHP with extensions"
-        uses: "shivammathur/setup-php@v2"
+        uses: "shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc" # 2.37.1
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: "${{ env.PHP_EXTENSIONS }}"
@@ -54,12 +54,12 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-phive-${{ matrix.dependencies }}-"
 
       - name: "Install PHIVE"
-        uses: "szepeviktor/phive@v1"
+        uses: "szepeviktor/phive@54bea80b5ac4e1b91f6df7aa071fcd5b2a8ee605" # v1.0.1
         with:
           home: "${{ runner.temp }}/.phive"
 
       - name: "Install PHP tools with PHIVE"
-        uses: "szepeviktor/phive-install@v1"
+        uses: "szepeviktor/phive-install@df144276db4732517dd8ea8d5dc45797b2f77ff1" # v1
         with:
           home: "${{ runner.temp }}/.phive"
           trustGpgKeys: "C00543248C87FB13,31C7E470E2138192,A978220305CD5C32"
@@ -112,7 +112,7 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Install PHP with extensions"
-        uses: "shivammathur/setup-php@v2"
+        uses: "shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc" # 2.37.1
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: "${{ env.PHP_EXTENSIONS }}"
@@ -131,12 +131,12 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-phive-${{ matrix.dependencies }}-"
 
       - name: "Install PHIVE"
-        uses: "szepeviktor/phive@v1"
+        uses: "szepeviktor/phive@54bea80b5ac4e1b91f6df7aa071fcd5b2a8ee605" # v1.0.1
         with:
           home: "${{ runner.temp }}/.phive"
 
       - name: "Install PHP tools with PHIVE"
-        uses: "szepeviktor/phive-install@v1"
+        uses: "szepeviktor/phive-install@df144276db4732517dd8ea8d5dc45797b2f77ff1" # v1
         with:
           home: "${{ runner.temp }}/.phive"
           trustGpgKeys: "C00543248C87FB13,31C7E470E2138192,A978220305CD5C32"
@@ -212,7 +212,7 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Install PHP with extensions"
-        uses: "shivammathur/setup-php@v2"
+        uses: "shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc" # 2.37.1
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: "${{ env.PHP_EXTENSIONS }}"
@@ -272,7 +272,7 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Install PHP with extensions"
-        uses: "shivammathur/setup-php@v2"
+        uses: "shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc" # 2.37.1
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: "${{ env.PHP_EXTENSIONS }}"


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

Tracking: DEVPROD-1072

Changes:
- Pins 3 distinct third-party action refs to full commit SHAs with readable version comments.
- Updates: .github/dependabot.yml, .github/workflows/ci.yaml
- Dependabot GitHub Actions coverage: created (.github/dependabot.yml)

Notes:
- `szepeviktor/phive-install` keeps `# v1` because the existing `@v1` tag resolves to this commit; the `v1.0.0` and `v1.0.1` tags point to different commits.

Verification commands:

```bash
# shivammathur/setup-php # 2.37.1 -> 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '.sha'
# expected: 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc

# szepeviktor/phive # v1.0.1 -> 54bea80b5ac4e1b91f6df7aa071fcd5b2a8ee605
gh api repos/szepeviktor/phive/commits/v1.0.1 --jq '.sha'
# expected: 54bea80b5ac4e1b91f6df7aa071fcd5b2a8ee605

# szepeviktor/phive-install # v1 -> df144276db4732517dd8ea8d5dc45797b2f77ff1
gh api repos/szepeviktor/phive-install/commits/v1 --jq '.sha'
# expected: df144276db4732517dd8ea8d5dc45797b2f77ff1
```
